### PR TITLE
Fix-pyproject-toml-file-python-version-dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "GNU General Public License v3.0"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.10"
 cbor2 = "^5.6.5"
 
 [build-system]


### PR DESCRIPTION
Small bugfix regarding the python version in the pyproject.toml file. The version requirement was set to strict.